### PR TITLE
Enable CORS

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -10,10 +10,13 @@ from flask import (
     Flask, jsonify, request
 )
 
+from flask_cors import CORS
+
 def create_app(test_config=None):
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_object('config.Config')
+    CORS(app)
 
     mysql = MySQL()
     mysql.init_app(app)

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -6,3 +6,4 @@
 
 pip3 install -e .
 pip3 install flask-mysql
+pip3 install flask-cors


### PR DESCRIPTION
This PR enables CORS for all origins. Fixes the `'Access-Control-Allow-Origin' missing` error when fetch() calls are made to /ping server apis.