### PR TITLE
feat: update, fix, and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ This template defines a single `/ping` route.
 ```python
 @app.route('/ping')
 def ping():
+    ping = request.args.get('ping')
+    if ping == "":
+        ping = 'To ping, or not to ping; that is the question.'
     return jsonify(
-        ping=request.args.get('ping'),
-        received_at=datetime.now(),
+        ping=ping,
+        received_at=datetime.utcnow(),
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python/Flask with MySQL template for Crafting Sandbox
 
-This is a Python/[Flask](https://flask.palletsprojects.com/en/2.0.x/) with MySQL template, configured for quick development setup in [Crafting Sandbox](https://crafting.readme.io/docs).
+This is a Python/[Flask](https://flask.palletsprojects.com/en/2.0.x/) with MySQL template, configured for quick development setup in [Crafting Sandbox](https://docs.sandboxes.cloud/docs).
 
 ## Specifications
 
@@ -41,37 +41,38 @@ You can launch the app by running:
 python3 -m flask run
 ```
 
-## App configuration
+## App Definition
 
-The following [App configuration](https://crafting.readme.io/docs/app-spec) was used to create this template:
+The following [App Definition](https://docs.sandboxes.cloud/docs/app-definition) was used to create this template:
 
 ```yaml
 endpoints:
-- http:
+- name: api
+  http:
     routes:
-    - backend:
-        port: http
+    - pathPrefix: "/"
+      backend:
         target: python-flask
-      path_prefix: /
-  name: app
-services:
-- description: Python/Flask template
-  name: python-flask
-  workspace:
-    checkouts:
-    - path: src/template-python-flask
-      repo:
-        git: https://github.com/crafting-dev/template-python-flask.git
-    ports:
-    - name: http
-      port: 3000
-      protocol: HTTP/TCP
-- managed_service:
-    properties:
-      database: superhero
-      password: batman
-      username: brucewayne
-    service_type: mysql
-    version: "8"
-  name: mysql
+        port: api
+    authProxy:
+      disabled: true
+workspaces:
+- name: python-flask
+  description: Template backend using Python/Flask
+  ports:
+  - name: api
+    port: 3000
+    protocol: HTTP/TCP
+  checkouts:
+  - path: backend
+    repo:
+      git: https://github.com/crafting-dev/template-python-flask
+dependencies:
+- name: mysql
+  serviceType: mysql
+  version: '8'
+  properties:
+    database: superhero
+    password: batman
+    username: brucewayne
 ```

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -36,8 +36,11 @@ def create_app(test_config=None):
 
     @app.route('/ping')
     def ping():
+        ping = request.args.get('ping')
+        if ping == "":
+            ping = 'To ping, or not to ping; that is the question.'
         return jsonify(
-            ping=request.args.get('ping'),
+            ping=ping,
             received_at=datetime.utcnow(),
         )
 


### PR DESCRIPTION
These set of PRs will fix all issues currently present in templates, such as routing issues for backend service, missing `npm installs` post checkout, outdated App Definitions, CORS issues, inconsistent query responses etc. With these updates, any frontend/backend configuration should work out of the box.

All templates will have the following behaviours:

- All 4 frontend templates will have the same interactive UI.
- All 7 backend templates will handle `/ping` requests, and will respond with either a query string `?ping=` (if present), or the phrase `'To ping, or not to ping; that is the question.'`, along with the current timestamp.

[Templates](https://sandboxes.cloud/sandboxes/templates) sandbox is currently available for testing in `crafting-contrib` using these updated branches, from an updated [template](https://sandboxes.cloud/apps/c6c54ee2top8eep5d6q0) App (which contains all template workspaces).