### PR TITLE
Update sandbox.sh to break system packages to get around pep668

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -4,4 +4,4 @@
 # Configure sandbox for quick workspace setup.
 # ============================================
 
-pip3 install -r requirements.txt
+pip3 install --break-system-packages -r requirements.txt


### PR DESCRIPTION
Adds --break-system-packages. A venv soluton may be better, but I'm not sure if it matters in this case. Feel free to reject this PR if it does.